### PR TITLE
Google Colab Direct Access Badge and `torch.device` CUDA independent

### DIFF
--- a/day1notebooks/lab1_transforms.ipynb
+++ b/day1notebooks/lab1_transforms.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Lab 1: Transforms\n",
     "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day1notebooks/lab1_transforms.ipynb)\n",
+    "\n",
     "This lab will walk you through using MONAI transforms to setup a data pipeline for training.\n",
     "\n",
     "First we'll import MONAI components:"
@@ -831,9 +833,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:monai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-monai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -845,7 +847,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day1notebooks/lab2_end_to_end.ipynb
+++ b/day1notebooks/lab2_end_to_end.ipynb
@@ -6,6 +6,9 @@
    "source": [
     "# Lab 2: End to end model training and validation with Pytorch, Ignite and MONAI\n",
     "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day1notebooks/lab2_end_to_end.ipynb)\n",
+    "\n",
     "## Overview\n",
     "\n",
     "This notebook takes you through the end to end workflow using for training a deep learning model.  You'll do the following:\n",
@@ -346,7 +349,7 @@
    "outputs": [],
    "source": [
     "learning_rate = 1e-5\n",
-    "device = torch.device(\"cuda:0\")\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "net = densenet121(spatial_dims=2, in_channels=1, out_channels=num_class).to(device)\n",
     "loss_function = torch.nn.CrossEntropyLoss()\n",
     "optimizer = torch.optim.Adam(net.parameters(), learning_rate)"
@@ -824,9 +827,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:monai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-monai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -838,7 +841,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day1notebooks/lab3_datasets.ipynb
+++ b/day1notebooks/lab3_datasets.ipynb
@@ -8,6 +8,9 @@
    },
    "source": [
     "# Lab 3: Datasets\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day1notebooks/lab3_datasets.ipynb)\n",
     "\n",
     "### Overview\n",
     "\n",
@@ -141,7 +144,7 @@
     "\n",
     "print(f\"Length of dataset is {len(dataset)}\")\n",
     "for item in dataset:\n",
-    "  print(item)"
+    "    print(item)"
    ]
   },
   {
@@ -182,7 +185,7 @@
    ],
    "source": [
     "for item in torch.utils.data.DataLoader(dataset, batch_size=2):\n",
-    "  print(item)"
+    "    print(item)"
    ]
   },
   {
@@ -227,21 +230,22 @@
    ],
    "source": [
     "class SquareIt(monai.transforms.MapTransform):\n",
-    "  \"\"\"a simple transform to return a squared number\"\"\"\n",
+    "\"\"\"a simple transform to return a squared number\"\"\"\n",
     "\n",
-    "  def __init__(self, keys):\n",
-    "    monai.transforms.MapTransform.__init__(self, keys)\n",
-    "    print(f\"keys to square it: {self.keys}\")\n",
+    "    def __init__(self, keys):\n",
+    "        monai.transforms.MapTransform.__init__(self, keys)\n",
+    "        print(f\"keys to square it: {self.keys}\")\n",
     "\n",
-    "  def __call__(self, x):\n",
-    "    key = self.keys[0]\n",
-    "    data = x[key]\n",
-    "    output = {key: data ** 2}\n",
-    "    return output\n",
+    "        \n",
+    "    def __call__(self, x):\n",
+    "        key = self.keys[0]\n",
+    "        data = x[key]\n",
+    "        output = {key: data ** 2}\n",
+    "        return output\n",
     "\n",
     "square_dataset = monai.data.Dataset(items, transform=SquareIt(keys='data'))\n",
     "for item in square_dataset:\n",
-    "  print(item)"
+    "    print(item)"
    ]
   },
   {
@@ -292,16 +296,16 @@
    ],
    "source": [
     "class SlowSquare(monai.transforms.MapTransform):\n",
-    "  \"\"\"a simple transform to slowly return a squared number\"\"\"\n",
+    "\"\"\"a simple transform to slowly return a squared number\"\"\"\n",
     "  \n",
-    "  def __init__(self, keys):\n",
-    "    monai.transforms.MapTransform.__init__(self, keys)\n",
-    "    print(f\"keys to square it: {self.keys}\")\n",
+    "    def __init__(self, keys):\n",
+    "        monai.transforms.MapTransform.__init__(self, keys)\n",
+    "        print(f\"keys to square it: {self.keys}\")\n",
     "\n",
-    "  def __call__(self, x):\n",
-    "    time.sleep(1.0)\n",
-    "    output = {key: x[key] ** 2 for key in self.keys}\n",
-    "    return output\n",
+    "    def __call__(self, x):\n",
+    "        time.sleep(1.0)\n",
+    "        output = {key: x[key] ** 2 for key in self.keys}\n",
+    "        return output\n",
     "\n",
     "square_dataset = monai.data.Dataset(items, transform=SlowSquare(keys='data'))"
    ]
@@ -686,13 +690,13 @@
     "dataset_2 = monai.data.Dataset(items)\n",
     "\n",
     "def concat(data):\n",
-    "  # data[0] is an element from dataset_1\n",
-    "  # data[1] is an element from dataset_2\n",
-    "  return (f\"{data[0]} + {data[1]} = {data[0] + data[1]}\",)\n",
+    "    # data[0] is an element from dataset_1\n",
+    "    # data[1] is an element from dataset_2\n",
+    "    return (f\"{data[0]} + {data[1]} = {data[0] + data[1]}\",)\n",
     "\n",
     "zipped_data = monai.data.ZipDataset([dataset_1, dataset_2], transform=concat)\n",
     "for item in zipped_data:\n",
-    "  print(item)"
+    "    print(item)"
    ]
   },
   {
@@ -806,7 +810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day1notebooks/lab3_networks.ipynb
+++ b/day1notebooks/lab3_networks.ipynb
@@ -8,6 +8,10 @@
    },
    "source": [
     "# Lab 3: Networks\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day1notebooks/lab3_networks.ipynb)\n",
+    "\n",
     "\n",
     "### Overview\n",
     "\n",
@@ -552,7 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/day1notebooks/lab3_post_transforms.ipynb
+++ b/day1notebooks/lab3_post_transforms.ipynb
@@ -8,6 +8,9 @@
    },
    "source": [
     "# Lab 3: Post Transforms\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day1notebooks/lab3_post_transforms.ipynb)\n",
     "\n",
     "### Overview\n",
     "\n",
@@ -993,7 +996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day2notebooks/day2_mednist_GAN_tutorial.ipynb
+++ b/day2notebooks/day2_mednist_GAN_tutorial.ipynb
@@ -5,6 +5,9 @@
    "metadata": {},
    "source": [
     "# Generative Adversarial Networks with MedNIST Dataset\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day2notebooks/day2_mednist_GAN_tutorial.ipynb)\n",
     "\n",
     "This notebook illustrates the use of MONAI for training a network to generate images from a random input tensor. A simple GAN is employed to do with a separate Generator and Discriminator networks.\n",
     "\n",
@@ -216,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device(\"cuda:0\")\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "disc_net = Discriminator(\n",
     "    in_shape=(1, 64, 64),\n",
     "    channels=(8, 16, 32, 64, 1),\n",
@@ -430,9 +433,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:monai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-monai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -444,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day2notebooks/day2_segment_challenge.ipynb
+++ b/day2notebooks/day2_segment_challenge.ipynb
@@ -8,6 +8,9 @@
    },
    "source": [
     "# Segmentation Exercise\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day2notebooks/day2_segment_challenge.ipynb)\n",
     "\n",
     "In this exercise we will segment the left ventricle of the heart in relatively small images using neural networks. \n",
     "Below is the code for setting up a segmentation network and training it. The network isn't very good, **so the exercise is to improve the quality of the segmentation by improving the network and/or the training scheme including data loading efficiency and data augmentation**. \n",
@@ -47,7 +50,7 @@
     "from torch.utils.data import DataLoader\n",
     "from monai.utils import progress_bar\n",
     "\n",
-    "device = torch.device(\"cuda:0\")\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "DATA_NPZ = \"https://github.com/ericspod/VPHSummerSchool2019/raw/master/scd_lvsegs.npz\"\n",
     "\n",
     "batch_size = 50\n",
@@ -401,9 +404,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python [conda env:monai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-monai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -415,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/day2notebooks/day2_segment_challenge_solution.ipynb
+++ b/day2notebooks/day2_segment_challenge_solution.ipynb
@@ -8,6 +8,9 @@
    },
    "source": [
     "# Segmentation Exercise\n",
+    "---\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Project-MONAI/MONAIBootcamp2020/blob/master/day2notebooks/day2_segment_challenge_solution.ipynb)\n",
     "\n",
     "In this exercise we will segment the left ventricle of the heart in relatively small images using neural networks. \n",
     "Below is the code for setting up a segmentation network and training it. The network isn't very good, **so the exercise is to improve the quality of the segmentation by improving the network and/or the training scheme including data loading efficiency and data augmentation**. \n",
@@ -62,7 +65,7 @@
     "    ToTensor\n",
     ")\n",
     "\n",
-    "device = torch.device(\"cuda:0\")\n",
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "DATA_NPZ = \"https://github.com/ericspod/VPHSummerSchool2019/raw/master/scd_lvsegs.npz\"\n",
     "\n",
     "batch_size = 300  # changed from original\n",
@@ -497,9 +500,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python [conda env:monai]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-monai-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -511,7 +514,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR introduces the following changes to all the notebooks:

- All notebooks now include on top an **Open on Colab** badge for direct link access.
- All the notebooks are now set on (_default_) "Python 3" kernel (to avoid confusion).
- Whenever a `torch.device` was used, the code has been changed to support both GPU and CPU
    * All direct device creation like `torch.device(cuda:0)` have been simply replaced with `torch.device("cuda:0" if torch.cuda.is_available() else "cpu")`

**Important**: 
- `day1_lab2_end_to_end.ipynb` contained formatting issues (`2` spaces tab instead of `4`) that have been fixed.